### PR TITLE
Changed MDB_GET_BOTH to MDB_GET_BOTH_RANGE in definition of Cursor.set_r...

### DIFF
--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -2486,7 +2486,7 @@ cursor_set_range_dup(CursorObject *self, PyObject *args, PyObject *kwds)
     }
     self->key = arg.key;
     self->val = arg.value;
-    return _cursor_get(self, MDB_GET_BOTH);
+    return _cursor_get(self, MDB_GET_BOTH_RANGE);
 }
 
 /**


### PR DESCRIPTION
...ange_dup in cpython.c

The documentation for Cursor.set_range_dup states that this method is ``equivalent to mdb_cursor_get() with MDB_GET_BOTH_RANGE''. However, the definition in cpython.c calls _cursor_get with MDB_GET_BOTH. As a result, Cursor.set_range_dup behaves exactly like Cursor.set_key_dup.

Cursor.set_range_dup(key, value) seeks to the first (k, v) pair such that key == k and v >= value, returning True on success or False if no such (k, v) exist.