### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ lmdb
 
 This is a universal Python binding for the `LMDB 'Lightning' Database
 <http://symas.com/mdb/>`_. Two variants are provided and automatically selected
-during install: a `CFFI <http://cffi.readthedocs.org/en/release-0.5/>`_ variant
+during install: a `CFFI <https://cffi.readthedocs.io/en/release-0.5/>`_ variant
 that supports `PyPy <http://www.pypy.org/>`_ and all versions of CPython >=2.6,
 and a C extension that supports CPython 2.5-2.7 and >=3.3. Both variants
 provide the same interface.

--- a/lmdb/__init__.py
+++ b/lmdb/__init__.py
@@ -21,7 +21,7 @@
 """
 cffi wrapper for OpenLDAP's "Lightning" MDB database.
 
-Please see http://lmdb.readthedocs.org/
+Please see https://lmdb.readthedocs.io/
 """
 
 import os

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -23,7 +23,7 @@
 """
 CPython/CFFI wrapper for OpenLDAP's "Lightning" MDB database.
 
-Please see http://lmdb.readthedocs.org/
+Please see https://lmdb.readthedocs.io/
 """
 
 from __future__ import absolute_import


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.