### PR TITLE
Make Travis-CI green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,29 @@
-language: c
+language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.5
+  - 3.6-dev
+  - nightly
+
+env:
+  - LMDB_FORCE_CFFI=1
+  - 
 install:
-setup:
+  - "sudo apt-get install gdb"
+  - "pip install cffi"
+
+  # this is a workaround for https://github.com/dw/py-lmdb/issues/132
+  - "git revert --no-commit 04ef5846262d9bee39938208af14cce28ebc1834"
+
+  - "python setup.py install"
+before_script:
+  - "source misc/helpers.sh"
+  
 script:
-    - "sudo ./misc/runtests-travisci.sh"
+  - "with_gdb py.test tests"
 
 notifications:
   email: false

--- a/lmdb/tool.py
+++ b/lmdb/tool.py
@@ -543,7 +543,7 @@ def cmd_edit(opts, args):
             cursor.put(key, value)
 
         for key in opts.delete or []:
-            txn.delete(key)
+            txn.delete(key, db=DB)
 
         for elem in opts.add_file or []:
             key, _, path = elem.partition('=')

--- a/lmdb/tool.py
+++ b/lmdb/tool.py
@@ -543,7 +543,7 @@ def cmd_edit(opts, args):
             cursor.put(key, value)
 
         for key in opts.delete or []:
-            txn.delete(key, db=DB)
+            txn.delete(key)
 
         for elem in opts.add_file or []:
             key, _, path = elem.partition('=')

--- a/misc/helpers.sh
+++ b/misc/helpers.sh
@@ -1,0 +1,27 @@
+quiet() {
+    "$@" > /tmp/$$ || { cat /tmp/$$; return 1; }
+}
+
+clean() {
+    git clean -qdfx
+    find /usr/local/lib -name '*lmdb*' | xargs rm -rf
+    find /usr/lib -name '*lmdb*' | xargs rm -rf
+}
+
+with_gdb() {
+    gdb --batch -x misc/gdb.commands --args "$@"
+}
+
+native() {
+    clean
+    quiet $1 setup.py develop
+    quiet $1 -c 'import lmdb.cpython'
+    with_gdb $1 -m pytest tests || fail=1
+}
+
+cffi() {
+    clean
+    LMDB_FORCE_CFFI=1 quiet $1 setup.py install
+    LMDB_FORCE_CFFI=1 quiet $1 -c 'import lmdb.cffi'
+    with_gdb $1 -m pytest tests || fail=1
+}

--- a/misc/runtests-ubuntu-12-04.sh
+++ b/misc/runtests-ubuntu-12-04.sh
@@ -1,32 +1,6 @@
 #!/bin/bash -ex
 
-quiet() {
-    "$@" > /tmp/$$ || { cat /tmp/$$; return 1; }
-}
-
-clean() {
-    git clean -qdfx
-    find /usr/local/lib -name '*lmdb*' | xargs rm -rf
-    find /usr/lib -name '*lmdb*' | xargs rm -rf
-}
-
-with_gdb() {
-    gdb --batch -x misc/gdb.commands --args "$@"
-}
-
-native() {
-    clean
-    quiet $1 setup.py develop
-    quiet $1 -c 'import lmdb.cpython'
-    with_gdb $1 -m pytest tests || fail=1
-}
-
-cffi() {
-    clean
-    LMDB_FORCE_CFFI=1 quiet $1 setup.py install
-    LMDB_FORCE_CFFI=1 quiet $1 -c 'import lmdb.cffi'
-    with_gdb $1 -m pytest tests || fail=1
-}
+source misc/helpers.sh
 
 native python2.5
 native python2.6


### PR DESCRIPTION
This PR splits tests by a python versions so Travis runs them separately. Also, drops 2.5, as it's not supported by Travis.