### PR TITLE
Make Travis-CI green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.6
   - 2.7
+  - 3.1
   - 3.2
   - 3.3
   - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,16 @@ python:
   - 2.7
   # - 3.1
   - 3.2
-  # - 3.3
-  # - 3.5
-  # - 3.6-dev
-  # - nightly
+  - 3.3
+  - 3.5
+  - 3.6-dev
+  - nightly
+  - pypy
 
 env:
   - LMDB_FORCE_CFFI=1
   - 
 install:
-  - 
-  - > 
-    if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then 
-      wget -qO ez_setup_24.py https://raw.githubusercontent.com/pypa/setuptools/bootstrap-py24/ez_setup.py && \
-      sudo apt-add-repository -y ppa:fkrull/deadsnakes && \
-      sudo apt-get update && \
-      sudo apt-get install python2.5-dev && \
-      sudo python2.5 ez_setup_24.py && \
-      sudo python2.5 -m easy_install py==1.4.20 pytest==2.5.2;
-    fi
   - sudo apt-get install gdb
   - pip install cffi
 
@@ -33,11 +24,16 @@ install:
   - python setup.py install
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install -I py==1.4.20 pytest==2.5.2; fi
 before_script:
-  - sudo source misc/helpers.sh
+  - source misc/helpers.sh
   
 script:
-  - with_gdb python -m pytest tests
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then sudo native python2.5; fi
+  - > 
+    if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; 
+      then 
+        sudo ./misc/runtests-travisci.sh 
+      else 
+        with_gdb python -m pytest tests; 
+    fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,27 @@
 language: python
 python:
+  - 2.6
   - 2.7
+  - 3.2
+  - 3.3
   - 3.5
+  - 3.6-dev
   - nightly
+
+env:
+  - LMDB_FORCE_CFFI=1
+  - 
 install:
-    - "python setup.py install"
-setup:
+  - "pip install cffi"
+
+  # this is a workaround for https://github.com/dw/py-lmdb/issues/132
+  - "git revert --no-commit 04ef5846262d9bee39938208af14cce28ebc1834"
+
+  - "python setup.py install"
+before_script:
+  
 script:
-    - "python -m pytest tests"
+  - "py.test tests"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - LMDB_FORCE_CFFI=1
   - 
 install:
+  - "sudo apt-get install gdb"
   - "pip install cffi"
 
   # this is a workaround for https://github.com/dw/py-lmdb/issues/132
@@ -19,9 +20,10 @@ install:
 
   - "python setup.py install"
 before_script:
+  - "source misc/helpers.sh"
   
 script:
-  - "py.test tests"
+  - "with_gdb py.test tests"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  # - 3.1
   - 3.2
   - 3.3
   - 3.5
@@ -16,10 +15,6 @@ env:
 install:
   - sudo apt-get install gdb
   - pip install cffi
-
-
-  # this is a workaround for https://github.com/dw/py-lmdb/issues/132
-  - git revert --no-commit 04ef5846262d9bee39938208af14cce28ebc1834
 
   - python setup.py install
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install -I py==1.4.20 pytest==2.5.2; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,42 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.1
+  # - 3.1
   - 3.2
-  - 3.3
-  - 3.5
-  - 3.6-dev
-  - nightly
+  # - 3.3
+  # - 3.5
+  # - 3.6-dev
+  # - nightly
 
 env:
   - LMDB_FORCE_CFFI=1
   - 
 install:
-  - "sudo apt-get install gdb"
-  - "pip install cffi"
+  - 
+  - > 
+    if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then 
+      wget -qO ez_setup_24.py https://raw.githubusercontent.com/pypa/setuptools/bootstrap-py24/ez_setup.py && \
+      sudo apt-add-repository -y ppa:fkrull/deadsnakes && \
+      sudo apt-get update && \
+      sudo apt-get install python2.5-dev && \
+      sudo python2.5 ez_setup_24.py && \
+      sudo python2.5 -m easy_install py==1.4.20 pytest==2.5.2;
+    fi
+  - sudo apt-get install gdb
+  - pip install cffi
+
 
   # this is a workaround for https://github.com/dw/py-lmdb/issues/132
-  - "git revert --no-commit 04ef5846262d9bee39938208af14cce28ebc1834"
+  - git revert --no-commit 04ef5846262d9bee39938208af14cce28ebc1834
 
-  - "python setup.py install"
+  - python setup.py install
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install -I py==1.4.20 pytest==2.5.2; fi
 before_script:
-  - "source misc/helpers.sh"
+  - sudo source misc/helpers.sh
   
 script:
-  - "with_gdb py.test tests"
+  - with_gdb python -m pytest tests
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then sudo native python2.5; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-language: c
+language: python
+python:
+  - 2.7
+  - 3.5
+  - nightly
 install:
+    - "python setup.py install"
 setup:
 script:
-    - "sudo ./misc/runtests-travisci.sh"
+    - "python -m pytest tests"
 
 notifications:
   email: false

--- a/misc/helpers.sh
+++ b/misc/helpers.sh
@@ -14,6 +14,7 @@ with_gdb() {
 
 native() {
     clean
+    unset LMDB_FORCE_CFFI
     quiet $1 setup.py develop
     quiet $1 -c 'import lmdb.cpython'
     with_gdb $1 -m pytest tests || fail=1

--- a/misc/helpers.sh
+++ b/misc/helpers.sh
@@ -1,0 +1,27 @@
+quiet() {
+    "$@" > /tmp/$$ || { cat /tmp/$$; return 1; }
+}
+
+clean() {
+    git clean -qdfx
+    find /usr/local/lib -name '*lmdb*' | xargs rm -rf
+    find /usr/lib -name '*lmdb*' | xargs rm -rf
+}
+
+with_gdb() {
+    gdb --batch -x misc/gdb.commands --args "$@"
+}
+
+native() {
+    clean
+    quiet $1 setup.py develop
+    quiet $1 -c 'import lmdb.cpython'
+    with_gdb $1 -m pytest tests || fail=1
+}
+
+cffi() {
+    clean
+    LMDB_FORCE_CFFI=1 quiet $1 setup.py install
+    LMDB_FORCE_CFFI=1 quiet $1 -c 'import lmdb.cffi'
+    with_gdb $1 -m pytest tests || fail=1
+}

--- a/misc/runtests-travisci.sh
+++ b/misc/runtests-travisci.sh
@@ -12,30 +12,17 @@ find /usr/local/lib -name '*setuptools*' | xargs rm -rf
 quiet add-apt-repository -y ppa:fkrull/deadsnakes
 quiet add-apt-repository -y ppa:pypy
 quiet apt-get -qq update
-quiet apt-get install --force-yes -qq \
-    python{2.5,2.6,2.7,3.2,3.3}-dev \
-    pypy-dev \
-    libffi-dev \
-    gdb
+quiet apt-get install --force-yes -qq python{2.5,2.6}-dev libffi-dev gdb
 
 wget -qO ez_setup_24.py \
-    https://bitbucket.org/pypa/setuptools/raw/bootstrap-py24/ez_setup.py
-wget -q https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
+    https://raw.githubusercontent.com/pypa/setuptools/bootstrap-py24/ez_setup.py
+wget -q https://raw.githubusercontent.com/pypa/setuptools/bootstrap/ez_setup.py
 
 quiet python2.5 ez_setup_24.py
 quiet python2.6 ez_setup.py
-quiet python2.7 ez_setup.py
-# quiet python3.1 ez_setup.py
-quiet python3.2 ez_setup.py
-quiet python3.3 ez_setup.py
-quiet pypy ez_setup.py
+
 
 quiet python2.5 -measy_install py==1.4.20 pytest==2.5.2
 quiet python2.6 -measy_install py==1.4.20 pytest==2.5.2 cffi
-quiet python2.7 -measy_install py==1.4.20 pytest==2.5.2 cffi
-# quiet python3.1 -measy_install py==1.4.20 pytest==2.5.2 cffi argparse
-quiet python3.2 -measy_install py==1.4.20 pytest==2.5.2 cffi
-quiet python3.3 -measy_install py==1.4.20 pytest==2.5.2 cffi
-quiet pypy -measy_install py==1.4.20 pytest==2.5.2
 
 source misc/runtests-ubuntu-12-04.sh

--- a/misc/runtests-ubuntu-12-04.sh
+++ b/misc/runtests-ubuntu-12-04.sh
@@ -4,14 +4,8 @@ source misc/helpers.sh
 
 native python2.5
 native python2.6
-native python2.7
-native python3.3
-cffi pypy
 cffi python2.6
-cffi python2.7
-# cffi python3.1
-cffi python3.2
-cffi python3.3
+
 
 [ "$fail" ] && exit 1
 exit 0

--- a/misc/runtests-ubuntu-12-04.sh
+++ b/misc/runtests-ubuntu-12-04.sh
@@ -1,32 +1,6 @@
 #!/bin/bash -ex
 
-quiet() {
-    "$@" > /tmp/$$ || { cat /tmp/$$; return 1; }
-}
-
-clean() {
-    git clean -qdfx
-    find /usr/local/lib -name '*lmdb*' | xargs rm -rf
-    find /usr/lib -name '*lmdb*' | xargs rm -rf
-}
-
-with_gdb() {
-    gdb --batch -x misc/gdb.commands --args "$@"
-}
-
-native() {
-    clean
-    quiet $1 setup.py develop
-    quiet $1 -c 'import lmdb.cpython'
-    with_gdb $1 -m pytest tests || fail=1
-}
-
-cffi() {
-    clean
-    LMDB_FORCE_CFFI=1 quiet $1 setup.py install
-    LMDB_FORCE_CFFI=1 quiet $1 -c 'import lmdb.cffi'
-    with_gdb $1 -m pytest tests || fail=1
-}
+source misc/helpers.sh
 
 native python2.5
 native python2.6


### PR DESCRIPTION
Managed to refactor tests while keeping python2.5 support by piggybacking it on python2.6 environment.
Both 2.5 and 2.6 tests will be run with the legacy test scripts, while the rest of the versions will fall under the new structure for .travis.yml