### PR TITLE
More correct and simpler mkdir() usage

### DIFF
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -29,6 +29,7 @@ Please see https://lmdb.readthedocs.io/
 from __future__ import absolute_import
 from __future__ import with_statement
 
+import errno
 import inspect
 import os
 import sys
@@ -701,8 +702,12 @@ class Environment(object):
         if rc:
             raise _error("mdb_env_set_maxdbs", rc)
 
-        if create and subdir and not (os.path.exists(path) or readonly):
-            os.mkdir(path, mode)
+        if create and subdir and not readonly:
+            try:
+                os.mkdir(path, mode)
+            except EnvironmentError as e:
+                if e.errno != errno.EEXIST:
+                    raise
 
         flags = _lib.MDB_NOTLS
         if not subdir:

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -1258,14 +1258,9 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     fspath = PyBytes_AS_STRING(fspath_obj);
 
     if(arg.create && arg.subdir && !arg.readonly) {
-        struct stat st;
-        errno = 0;
-        stat(fspath, &st);
-        if(errno == ENOENT) {
-            if(mkdir(fspath, arg.mode)) {
-                PyErr_SetFromErrnoWithFilename(PyExc_OSError, fspath);
-                goto fail;
-            }
+        if(mkdir(fspath, arg.mode) && errno != EEXIST) {
+            PyErr_SetFromErrnoWithFilename(PyExc_OSError, fspath);
+            goto fail;
         }
     }
 


### PR DESCRIPTION
Instead of checking if the directory exists and creating it if not, try
to create it and handle the error.