### PR TITLE
Fix ns polution for drop

### DIFF
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -1128,6 +1128,7 @@ class _Database(object):
                  integerkey, integerdup, dupfixed):
         env._deps.add(self)
         self._deps = set()
+        self._name = name
 
         flags = 0
         if reverse_key:
@@ -1335,6 +1336,8 @@ class Transaction(object):
         self._mutations += 1
         if rc:
             raise _error("mdb_drop", rc)
+        if db._name in self.env._dbs:
+            del self.env._dbs[db._name]
 
     def _cache_spare(self):
         # In order to avoid taking and maintaining a lock, a race is allowed

--- a/tests/txn_test.py
+++ b/tests/txn_test.py
@@ -266,6 +266,29 @@ class DropTest(unittest.TestCase):
         self.assertRaises(lmdb.InvalidParameterError,
             lambda: txn.drop(db1))
 
+    def test_double_delete(self):
+        _, env = testlib.temp_env()
+
+        db1 = env.open_db(B('db1'))
+        txn = env.begin(write=True, db=db1)
+        txn.put(B('a'), B('a'), db=db1)
+        txn.drop(db1)
+        self.assertRaises(lmdb.InvalidParameterError,
+            lambda: txn.get(B('a'), db=db1))
+        self.assertRaises(lmdb.InvalidParameterError,
+            lambda: txn.drop(db1))
+        txn.commit()
+
+        db1 = env.open_db(B('db1'))
+        txn = env.begin(write=True, db=db1)
+        txn.put(B('a'), B('a'), db=db1)
+        txn.drop(db1)
+        self.assertRaises(lmdb.InvalidParameterError,
+            lambda: txn.get(B('a'), db=db1))
+        self.assertRaises(lmdb.InvalidParameterError,
+            lambda: txn.drop(db1))
+        txn.commit()
+
 
 class CommitTest(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
Currently there is an issue with the CFFI module and the database 'drop' method. Once you have dropped a named database within an environment, that name cannot be used again without first closing the environment.

I've added a test "test_double_delete" that highlights the issue, this passes on cpython but fails for pypy.

Then there is one minor change to "drop" which simply updates the "_dbs" dictionary that the environment is using to keep track of open databases. Essentially drop was closing the database as far as lmdb was concerned but leaving open a reference within py-lmdb.

(all tests pass for cpython and pypy with this applied)